### PR TITLE
Updated to only make pam helper setuid

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -372,4 +372,4 @@ iconsdir = $(datadir)/xsecurelock
 icons_DATA = icons/lock.png
 
 install-exec-hook:
-	chmod 4755 $(helpersdir)/authproto_pam
+	chmod 4755 $(DESTDIR)$(helpersdir)/authproto_pam

--- a/Makefile.am
+++ b/Makefile.am
@@ -372,4 +372,4 @@ iconsdir = $(datadir)/xsecurelock
 icons_DATA = icons/lock.png
 
 install-exec-hook:
-	chmod 4755 $(DESTDIR)$(bindir)/xsecurelock
+	chmod 4755 $(helpersdir)/authproto_pam

--- a/Makefile.am
+++ b/Makefile.am
@@ -371,5 +371,5 @@ endif
 iconsdir = $(datadir)/xsecurelock
 icons_DATA = icons/lock.png
 
-install-exec-hook:
+install-data-hook:
 	chmod 4755 $(DESTDIR)$(helpersdir)/authproto_pam


### PR DESCRIPTION
Only the PAM module (helper) needs to be setuid